### PR TITLE
Move shellcheck directive

### DIFF
--- a/borgmatic/run-borgmatic.sh
+++ b/borgmatic/run-borgmatic.sh
@@ -1,3 +1,3 @@
-# shellcheck shell=sh
 #!/usr/bin/with-contenv sh
+# shellcheck shell=sh
 exec borgmatic -c /borgmatic/config.yaml 2>&1 | s6-log -v /var/log/borgmatic


### PR DESCRIPTION
Shebang must be the first line for script to run correctly